### PR TITLE
Fix to remind us of the center coordinate.

### DIFF
--- a/3_skimage_processing_from_numpy_and_scipy.Rmd
+++ b/3_skimage_processing_from_numpy_and_scipy.Rmd
@@ -1003,8 +1003,9 @@ j_coords
 ```
 
 ```{python}
-# The image center in pixels
-c_i, c_j = dim_0 / 2, dim_1 / 2
+# The coordinate of the image center in pixels.  Remember that pixel indices
+# start at 0.
+c_i, c_j = (dim_0 - 1) / 2, (dim_1 - 1) / 2
 # Radius
 r = 275
 ```
@@ -1066,11 +1067,13 @@ image:
 
 ```{python}
 # Solution pt 1.
-cam_c_i, cam_c_j = np.array(camera.shape) / 2
+cam_c_i, cam_c_j = (np.array(camera.shape) - 1) / 2
 p = 55  # By experiment.
-i_camera, j_camera = np.meshgrid(np.arange(camera.shape[0]), np.arange(camera.shape[1]))
+i_cam, j_cam = np.meshgrid(np.arange(camera.shape[0]),
+                           np.arange(camera.shape[1]),
+                           indexing='ij')
 # Apply formula to make mask.
-mask_camera = ((i_camera - cam_c_i) ** 3 + (j_camera - cam_c_j) ** 3) ** (1 / 3) > p
+mask_camera = ((i_cam - cam_c_i) ** 3 + (j_cam - cam_c_j) ** 3) ** (1 / 3) > p
 plt.imshow(mask_camera);
 ```
 


### PR DESCRIPTION
I forgot the center coordinate is at (shape - 1) / 2, not shape / 2.

For example, consider a 5 x 3 image.

Center coordinate is 2, 1 = (4 / 2, 2 / 2).
